### PR TITLE
Improve cert generation for environment

### DIFF
--- a/sitecore-xm1/docker/start.ps1
+++ b/sitecore-xm1/docker/start.ps1
@@ -12,7 +12,12 @@ docker system prune -f
 ## load variables
 #----------------------------------------------------------
 
-$url = Get-EnvVar -Key CM_HOST
+$urls = @()
+$cmUrl = Get-EnvVar -Key CM_HOST
+
+$urls += $cmUrl
+$altHosts = Get-EnvVar -Key ALT_HOST
+$altHostsList = $altHosts.Replace('`', '').Split(',') | Foreach-Object { $urls += $_ }
 
 #----------------------------------------------------------
 ## check license is present
@@ -29,7 +34,7 @@ if (-not (Test-Path (Join-Path $licensePath "license.xml"))) {
 #----------------------------------------------------------
 
 if (-not (Test-Path .\traefik\certs\cert.pem)) {
-    .\tools\mkcert.ps1 -FullHostName ($url -replace "^.+?(\.)", "")
+    .\tools\mkcert.ps1 -FullHostName $urls
 }
 
 #----------------------------------------------------------
@@ -45,5 +50,5 @@ Read-UserEnvFile
 docker-compose up -d
 
 Wait-SiteResponsive
-Write-Host "`n`nDone... opening https://$($url)" -ForegroundColor DarkGray
-start "https://$url"
+Write-Host "`n`nDone... opening https://$($cmUrl)" -ForegroundColor DarkGray
+start "https://$cmUrl"

--- a/sitecore-xm1/docker/tools/mkcert.ps1
+++ b/sitecore-xm1/docker/tools/mkcert.ps1
@@ -6,7 +6,6 @@
 Param(
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
-    [string] 
     $FullHostName
 )
 
@@ -24,9 +23,18 @@ try {
             throw "Invalid mkcert.exe file"
         }
     }
+
+    $hosts = @()
+
+    foreach ($url in $FullHostName) {
+        $hosts += "*.$($url -replace '^.+?(\.)', '')"
+    }
+
+    $hosts += "*.localho.st"
+
     Write-Host "Generating Traefik TLS certificate..." -ForegroundColor Green
     & $mkcert -install
-    & $mkcert -key-file key.pem -cert-file cert.pem "*.$($FullHostName)"
+    & $mkcert -key-file key.pem -cert-file cert.pem $hosts
 }
 catch {
     Write-Host "An error occurred while attempting to generate TLS certificate: $_" -ForegroundColor Red


### PR DESCRIPTION
I have a case where my site is multisite. The host names end up coming out as follows:

  - cm.mysite1.localho.st
  - cm.mysite2.localho.st

The resulting certs only allow for the first domain + `*.localho.st`.

These updates modify the startup to generate a more advanced multi-SAN cert:

  - *.mysite1.localho.st
  - *.mysite2.localho.st
  - *.localho.st